### PR TITLE
refac(utils): review the codes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@ ipipeline.egg-info/
 
 # files
 .env
+.coverage
 tmp.py
 notes.md

--- a/ipipeline/__init__.py
+++ b/ipipeline/__init__.py
@@ -4,4 +4,4 @@ The ipipeline package is a micro framework for building and executing
 pipelines from different domains.
 """
 
-__version__ = '0.13.0'
+__version__ = '0.14.0'

--- a/ipipeline/cli/actions.py
+++ b/ipipeline/cli/actions.py
@@ -1,7 +1,7 @@
 """Functions related to the action procedure."""
 
-from ipipeline.utils.instance import obtain_mod_inst
-from ipipeline.utils.system import create_directory, create_file
+from ipipeline.utils.instance import get_inst
+from ipipeline.utils.system import build_directory, build_file
 
 
 def create_project(path: str, name: str) -> None:
@@ -27,10 +27,10 @@ def create_project(path: str, name: str) -> None:
 
     proj_path = f'{path}/{name}'
     pkg_path = f'{proj_path}/{name}'
-    create_directory(proj_path, missing=True)
+    build_directory(proj_path, parents=True)
 
     for proj_dir in ['io', 'requirements', 'tests', name]:
-        create_directory(f'{proj_path}/{proj_dir}')
+        build_directory(f'{proj_path}/{proj_dir}')
 
     for proj_file in [
         '.gitignore', 
@@ -40,13 +40,13 @@ def create_project(path: str, name: str) -> None:
         'README.md', 
         'setup.py'
     ]:
-        create_file(f'{proj_path}/{proj_file}')
+        build_file(f'{proj_path}/{proj_file}')
 
     for pkg_dir in ['configs', 'pipelines', 'tasks']:
-        create_directory(f'{pkg_path}/{pkg_dir}')
+        build_directory(f'{pkg_path}/{pkg_dir}')
 
     for pkg_file in ['exceptions.py', '__init__.py', '__main__.py']:
-        create_file(f'{pkg_path}/{pkg_file}')
+        build_file(f'{pkg_path}/{pkg_file}')
 
 
 def execute_pipeline(mod_name: str, func_name: str, exe_type: str) -> None:
@@ -75,8 +75,8 @@ def execute_pipeline(mod_name: str, func_name: str, exe_type: str) -> None:
         Informs that the node was not executed by the executor.
     """
 
-    pipeline = obtain_mod_inst(mod_name, func_name)()
-    executor = obtain_mod_inst(
+    pipeline = get_inst(mod_name, func_name)()
+    executor = get_inst(
         'ipipeline.execution.executors', f'{exe_type.capitalize()}Executor'
     )()
     executor.add_pipeline(pipeline)

--- a/ipipeline/cli/execution.py
+++ b/ipipeline/cli/execution.py
@@ -37,5 +37,5 @@ def execute_cli(args: List[str]) -> None:
 
         sys.exit(0)
     except Exception as error:
-        print('error:', ': '.join(error.args), file=sys.stderr)
+        print('error:', str(error), file=sys.stderr)
         sys.exit(1)

--- a/ipipeline/exceptions.py
+++ b/ipipeline/exceptions.py
@@ -4,41 +4,44 @@ The exceptions are bound to a module rather than a specific error. To
 inform about the specifications of an error the parameters must be used.
 """
 
+from typing import List
+
+
 class BaseError(Exception):
     """Informs the occurrence of an error related to the ipipeline package.
 
     Attributes
     ----------
-    _descr : str
-        Description of the error.
-    _detail : str
-        Detail of the error represented as a valid expression.
+    _text : str
+        Text of the error.
+    _causes : List[str]
+        Causes of the error.
     """
 
-    def __init__(self, descr: str, detail: str) -> None:
+    def __init__(self, text: str, causes: List[str]) -> None:
         """Initializes the attributes.
 
         Parameters
         ----------
-        descr : str
-            Description of the error.
-        detail : str
-            Detail of the error represented as a valid expression.
+        text : str
+            Text of the error.
+        causes : List[str]
+            Causes of the error.
         """
 
-        self._descr = descr
-        self._detail = detail
+        self._text = text
+        self._causes = causes
 
     def __str__(self) -> str:
-        """Obtains the error message.
+        """Builds the error message.
 
         Returns
         -------
-        error_msg : str
-            Error message.
+        msg : str
+            Message of the error.
         """
 
-        return f'{self._descr}: {self._detail}'
+        return f'{self._text}: {", ".join(self._causes)}'
 
 
 class BuildingError(BaseError):
@@ -46,10 +49,10 @@ class BuildingError(BaseError):
 
     Attributes
     ----------
-    _descr : str
-        Description of the error.
-    _detail : str
-        Detail of the error represented as a valid expression.
+    _text : str
+        Text of the error.
+    _causes : List[str]
+        Causes of the error.
     """
 
     pass
@@ -60,10 +63,10 @@ class CatalogError(BaseError):
 
     Attributes
     ----------
-    _descr : str
-        Description of the error.
-    _detail : str
-        Detail of the error represented as a valid expression.
+    _text : str
+        Text of the error.
+    _causes : List[str]
+        Causes of the error.
     """
 
     pass
@@ -74,10 +77,10 @@ class ExecutorError(BaseError):
 
     Attributes
     ----------
-    _descr : str
-        Description of the error.
-    _detail : str
-        Detail of the error represented as a valid expression.
+    _text : str
+        Text of the error.
+    _causes : List[str]
+        Causes of the error.
     """
 
     pass
@@ -88,10 +91,10 @@ class InfoError(BaseError):
 
     Attributes
     ----------
-    _descr : str
-        Description of the error.
-    _detail : str
-        Detail of the error represented as a valid expression.
+    _text : str
+        Text of the error.
+    _causes : List[str]
+        Causes of the error.
     """
 
     pass
@@ -102,10 +105,10 @@ class InstanceError(BaseError):
 
     Attributes
     ----------
-    _descr : str
-        Description of the error.
-    _detail : str
-        Detail of the error represented as a valid expression.
+    _text : str
+        Text of the error.
+    _causes : List[str]
+        Causes of the error.
     """
 
     pass
@@ -116,10 +119,10 @@ class PipelineError(BaseError):
 
     Attributes
     ----------
-    _descr : str
-        Description of the error.
-    _detail : str
-        Detail of the error represented as a valid expression.
+    _text : str
+        Text of the error.
+    _causes : List[str]
+        Causes of the error.
     """
 
     pass
@@ -130,10 +133,10 @@ class SortingError(BaseError):
 
     Attributes
     ----------
-    _descr : str
-        Description of the error.
-    _detail : str
-        Detail of the error represented as a valid expression.
+    _text : str
+        Text of the error.
+    _causes : List[str]
+        Causes of the error.
     """
 
     pass
@@ -144,10 +147,10 @@ class SystemError(BaseError):
 
     Attributes
     ----------
-    _descr : str
-        Description of the error.
-    _detail : str
-        Detail of the error represented as a valid expression.
+    _text : str
+        Text of the error.
+    _causes : List[str]
+        Causes of the error.
     """
 
     pass

--- a/ipipeline/execution/building.py
+++ b/ipipeline/execution/building.py
@@ -119,5 +119,5 @@ def _check_diff_outputs_qty(outputs_qty: int, returns_qty: int) -> None:
     if outputs_qty != returns_qty:
         raise BuildingError(
             'outputs_qty is not equal to the returns_qty', 
-            f'{outputs_qty} != {returns_qty}'
+            [f'{outputs_qty} != {returns_qty}']
         )

--- a/ipipeline/execution/executors.py
+++ b/ipipeline/execution/executors.py
@@ -10,7 +10,7 @@ from ipipeline.exceptions import ExecutorError
 from ipipeline.structure.catalog import Catalog
 from ipipeline.structure.pipeline import Pipeline
 from ipipeline.structure.signal import Signal
-from ipipeline.utils.instance import check_none_arg
+from ipipeline.utils.checking import check_none
 
 
 logger = logging.getLogger(name=__name__)
@@ -55,7 +55,7 @@ class BaseExecutor(ABC):
 
         self.add_pipeline(pipeline)
         self.add_catalog(catalog)
-        self._signals = check_none_arg(signals, {})
+        self._signals = check_none(signals, {})
 
     @property
     def pipeline(self) -> Pipeline:
@@ -108,7 +108,7 @@ class BaseExecutor(ABC):
             Informs that the id was not validated according to the pattern.
         """
 
-        self._pipeline = check_none_arg(
+        self._pipeline = check_none(
             pipeline, Pipeline('p0', tags=['default'])
         )
 
@@ -126,7 +126,7 @@ class BaseExecutor(ABC):
             Informs that the id was not validated according to the pattern.
         """
 
-        self._catalog = check_none_arg(
+        self._catalog = check_none(
             catalog, Catalog('c0', tags=['default'])
         )
 

--- a/ipipeline/execution/executors.py
+++ b/ipipeline/execution/executors.py
@@ -189,7 +189,7 @@ class BaseExecutor(ABC):
 
         if type not in valid_types:
             raise ExecutorError(
-                'type not found in the valid_types', f'type == {type}'
+                'type not found in the valid_types', [f'type == {type}']
             )
 
     def execute_node(self, id: str) -> Dict[str, Any]:
@@ -223,7 +223,7 @@ class BaseExecutor(ABC):
             return task_outputs
         except Exception as error:
             raise ExecutorError(
-                'node not executed by the executor', f'id == {id}'
+                'node not executed by the executor', [f'id == {id}']
             ) from error
 
     def obtain_topo_order(self) -> List[list]:

--- a/ipipeline/execution/sorting.py
+++ b/ipipeline/execution/sorting.py
@@ -94,7 +94,7 @@ def _obtain_in_conns_qty(graph: Dict[str, list]) -> Dict[str, int]:
             except KeyError as error:
                 raise SortingError(
                     'dst_node_id not specified as a src_node_id', 
-                    f'dst_node_id == {dst_node_id}'
+                    [f'dst_node_id == {dst_node_id}']
                 ) from error
 
     return in_conns_qty
@@ -147,5 +147,5 @@ def _check_circular_dependency(nodes_qty: int, ind_nodes_qty: int) -> None:
     if nodes_qty != ind_nodes_qty:
         raise SortingError(
             'circular dependency found in the graph', 
-            f'{nodes_qty} != {ind_nodes_qty}'
+            [f'{nodes_qty} != {ind_nodes_qty}']
         )

--- a/ipipeline/structure/catalog.py
+++ b/ipipeline/structure/catalog.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List
 
 from ipipeline.exceptions import CatalogError
 from ipipeline.structure.info import Info
-from ipipeline.utils.instance import check_none_arg
+from ipipeline.utils.checking import check_none
 
 
 class Catalog(Info):
@@ -47,7 +47,7 @@ class Catalog(Info):
             Informs that the id was not validated according to the pattern.
         """
 
-        self._items = check_none_arg(items, {})
+        self._items = check_none(items, {})
 
         super().__init__(id, tags=tags)
 

--- a/ipipeline/structure/catalog.py
+++ b/ipipeline/structure/catalog.py
@@ -120,7 +120,7 @@ class Catalog(Info):
             return self._items[id]
         except KeyError as error:
             raise CatalogError(
-                'id not found in the _items', f'id == {id}'
+                'id not found in the _items', [f'id == {id}']
             ) from error
 
     def remove_item(self, id: str) -> None:
@@ -141,7 +141,7 @@ class Catalog(Info):
             del self._items[id]
         except KeyError as error:
             raise CatalogError(
-                'id not found in the _items', f'id == {id}'
+                'id not found in the _items', [f'id == {id}']
             ) from error
 
     def remove_items(self) -> None:

--- a/ipipeline/structure/info.py
+++ b/ipipeline/structure/info.py
@@ -93,7 +93,7 @@ class Info:
             raise InfoError(
                 'id not validated according to the pattern '
                 '(letters, digits, underscores and/or dashes)', 
-                f'id == {id}'
+                [f'id == {id}']
             )
 
     def __repr__(self) -> str:

--- a/ipipeline/structure/info.py
+++ b/ipipeline/structure/info.py
@@ -4,7 +4,8 @@ import re
 from typing import List
 
 from ipipeline.exceptions import InfoError
-from ipipeline.utils.instance import build_inst_repr, check_none_arg
+from ipipeline.utils.checking import check_none
+from ipipeline.utils.instance import build_repr
 
 
 class Info:
@@ -38,7 +39,7 @@ class Info:
         """
 
         self._id = self._check_valid_id(id)
-        self._tags = check_none_arg(tags, [])
+        self._tags = check_none(tags, [])
 
     @property
     def id(self) -> str:
@@ -104,4 +105,4 @@ class Info:
             Representation of the instance.
         """
 
-        return build_inst_repr(self)
+        return build_repr(self)

--- a/ipipeline/structure/node.py
+++ b/ipipeline/structure/node.py
@@ -3,7 +3,7 @@
 from typing import Any, Callable, Dict, List
 
 from ipipeline.structure.info import Info
-from ipipeline.utils.instance import check_none_arg
+from ipipeline.utils.checking import check_none
 
 
 class Node(Info):
@@ -72,8 +72,8 @@ class Node(Info):
         """
 
         self._task = task
-        self._inputs = check_none_arg(inputs, {})
-        self._outputs = check_none_arg(outputs, [])
+        self._inputs = check_none(inputs, {})
+        self._outputs = check_none(outputs, [])
 
         super().__init__(id, tags=tags)
 

--- a/ipipeline/structure/pipeline.py
+++ b/ipipeline/structure/pipeline.py
@@ -6,7 +6,7 @@ from ipipeline.exceptions import PipelineError
 from ipipeline.structure.conn import Conn
 from ipipeline.structure.info import Info
 from ipipeline.structure.node import Node
-from ipipeline.utils.instance import check_none_arg
+from ipipeline.utils.checking import check_none
 
 
 class Pipeline(Info):
@@ -66,9 +66,9 @@ class Pipeline(Info):
             Informs that the id was not validated according to the pattern.
         """
 
-        self._graph = check_none_arg(graph, {})
-        self._nodes = check_none_arg(nodes, {})
-        self._conns = check_none_arg(conns, {})
+        self._graph = check_none(graph, {})
+        self._nodes = check_none(nodes, {})
+        self._conns = check_none(conns, {})
 
         super().__init__(id, tags=tags)
 

--- a/ipipeline/structure/pipeline.py
+++ b/ipipeline/structure/pipeline.py
@@ -173,7 +173,7 @@ class Pipeline(Info):
 
         if node_id in self._nodes.keys():
             raise PipelineError(
-                'node_id found in the _nodes', f'node_id == {node_id}'
+                'node_id found in the _nodes', [f'node_id == {node_id}']
             )
 
     def add_conn(
@@ -233,7 +233,7 @@ class Pipeline(Info):
 
         if conn_id in self._conns.keys():
             raise PipelineError(
-                'conn_id found in the _conns', f'conn_id == {conn_id}'
+                'conn_id found in the _conns', [f'conn_id == {conn_id}']
             )
 
     def _check_inexistent_node_id(self, node_id: str) -> None:
@@ -252,5 +252,5 @@ class Pipeline(Info):
 
         if node_id not in self._nodes.keys():
             raise PipelineError(
-                'node_id not found in the _nodes', f'node_id == {node_id}'
+                'node_id not found in the _nodes', [f'node_id == {node_id}']
             )

--- a/ipipeline/utils/checking.py
+++ b/ipipeline/utils/checking.py
@@ -1,0 +1,25 @@
+"""Functions related to the checking procedures."""
+
+from typing import Any
+
+
+def check_none(data: Any, default: Any) -> Any:
+    """Checks if the data is None.
+
+    Parameters
+    ----------
+    data : Any
+        Data.
+    default : Any
+        Default value to assign to the data in case it is None.
+
+    Returns
+    -------
+    data : Any
+        Data with its original or default value.
+    """
+
+    if data is None:
+        data = default
+
+    return data

--- a/ipipeline/utils/checking.py
+++ b/ipipeline/utils/checking.py
@@ -3,23 +3,23 @@
 from typing import Any
 
 
-def check_none(data: Any, default: Any) -> Any:
-    """Checks if the data is None.
+def check_none(item: Any, default: Any) -> Any:
+    """Checks if an item is None.
 
     Parameters
     ----------
-    data : Any
-        Data.
+    item : Any
+        Item.
     default : Any
-        Default value to assign to the data in case it is None.
+        Default to assign in case the item is None.
 
     Returns
     -------
-    data : Any
-        Data with its original or default value.
+    item : Any
+        Item.
     """
 
-    if data is None:
-        data = default
+    if item is None:
+        item = default
 
-    return data
+    return item

--- a/ipipeline/utils/instance.py
+++ b/ipipeline/utils/instance.py
@@ -46,7 +46,7 @@ def build_repr(inst: object) -> str:
     return repr
 
 
-def obtain_mod_inst(mod_name: str, inst_name: str) -> object:
+def get_inst(mod_name: str, inst_name: str) -> object:
     """Gets an instance from a module.
 
     Parameters

--- a/ipipeline/utils/instance.py
+++ b/ipipeline/utils/instance.py
@@ -8,15 +8,15 @@ from pathlib import Path
 from ipipeline.exceptions import InstanceError
 
 
-def build_inst_repr(inst: object) -> str:
+def build_repr(inst: object) -> str:
     """Builds the representation of an instance.
 
-    The class name and the parameters in the initializer signature are 
-    used to create the representation.
+    The class name and the initializer parameters are used to create the 
+    representation.
 
     Parameters
     ----------
-    instance : object
+    inst : object
         Instance of a class.
 
     Returns
@@ -41,7 +41,9 @@ def build_inst_repr(inst: object) -> str:
 
         repr += f'{param.name}={value}, '
 
-    return f'{repr})'.replace(', )', ')')
+    repr = f'{repr})'.replace(', )', ')')
+
+    return repr
 
 
 def obtain_mod_inst(mod_name: str, inst_name: str) -> object:

--- a/ipipeline/utils/instance.py
+++ b/ipipeline/utils/instance.py
@@ -4,31 +4,8 @@ import sys
 from importlib import import_module
 from inspect import signature
 from pathlib import Path
-from typing import Any
 
 from ipipeline.exceptions import InstanceError
-
-
-def check_none_arg(arg: Any, default: Any) -> Any:
-    """Checks if the arg is None.
-
-    Parameters
-    ----------
-    arg : Any
-        Argument of a callable.
-    default : Any
-        Default value to assign to the arg if it is None.
-
-    Returns
-    -------
-    arg : Any
-        Argument of a callable with its original or default value.
-    """
-
-    if arg is None:
-        arg = default
-
-    return arg
 
 
 def build_inst_repr(inst: object) -> str:

--- a/ipipeline/utils/instance.py
+++ b/ipipeline/utils/instance.py
@@ -47,22 +47,24 @@ def build_repr(inst: object) -> str:
 
 
 def obtain_mod_inst(mod_name: str, inst_name: str) -> object:
-    """Obtains an instance declared in a module.
+    """Gets an instance from a module.
 
     Parameters
     ----------
     mod_name : str
-        Name of the module in absolute terms (package.module).
+        Name of the module in absolute terms.
     inst_name : str
-        Name of the instance declared in the module.
+        Name of the instance located in the module.
 
     Returns
     -------
-    instance : object
+    inst : object
         Instance of a class.
 
     Raises
     ------
+    InstanceError
+        Informs that the mod_name was not found in the package.
     InstanceError
         Informs that the inst_name was not found in the module.
     """
@@ -70,8 +72,14 @@ def obtain_mod_inst(mod_name: str, inst_name: str) -> object:
     sys.path.append(str(Path(mod_name.split('.')[0]).resolve()))
 
     try:
-        return getattr(import_module(mod_name), inst_name)
-    except (ModuleNotFoundError, AttributeError) as error:
+        inst = getattr(import_module(mod_name), inst_name)
+
+        return inst
+    except ModuleNotFoundError as error:
+        raise InstanceError(
+            'mod_name not found in the package', f'mod_name == {mod_name}'
+        ) from error
+    except AttributeError as error:
         raise InstanceError(
             'inst_name not found in the module', f'inst_name == {inst_name}'
         ) from error

--- a/ipipeline/utils/instance.py
+++ b/ipipeline/utils/instance.py
@@ -77,9 +77,9 @@ def get_inst(mod_name: str, inst_name: str) -> object:
         return inst
     except ModuleNotFoundError as error:
         raise InstanceError(
-            'mod_name not found in the package', f'mod_name == {mod_name}'
+            'mod_name not found in the package', [f'mod_name == {mod_name}']
         ) from error
     except AttributeError as error:
         raise InstanceError(
-            'inst_name not found in the module', f'inst_name == {inst_name}'
+            'inst_name not found in the module', [f'inst_name == {inst_name}']
         ) from error

--- a/ipipeline/utils/system.py
+++ b/ipipeline/utils/system.py
@@ -34,11 +34,11 @@ def build_directory(path: str, **key_args: dict) -> None:
         path.mkdir(**key_args)
     except FileExistsError as error:
         raise SystemError(
-            'path found in the file system', f'path == {path}'
+            'path found in the file system', [f'path == {path}']
         ) from error
     except FileNotFoundError as error:
         raise SystemError(
-            'path not found in the file system', f'path == {path}'
+            'path not found in the file system', [f'path == {path}']
         ) from error
 
 
@@ -67,9 +67,9 @@ def build_file(path: str, **key_args: dict) -> None:
         path.touch(**key_args)
     except FileExistsError as error:
         raise SystemError(
-            'path found in the file system', f'path == {path}'
+            'path found in the file system', [f'path == {path}']
         ) from error
     except FileNotFoundError as error:
         raise SystemError(
-            'path not found in the file system', f'path == {path}'
+            'path not found in the file system', [f'path == {path}']
         ) from error

--- a/ipipeline/utils/system.py
+++ b/ipipeline/utils/system.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from ipipeline.exceptions import SystemError
 
 
-def create_directory(
+def build_directory(
     path: str, missing: bool = False, suppressed: bool = False
 ) -> None:
     """Creates a directory in the file system.
@@ -40,7 +40,7 @@ def create_directory(
         ) from error
 
 
-def create_file(path: str, suppressed: bool = False) -> None:
+def build_file(path: str, suppressed: bool = False) -> None:
     """Creates a file in the file system.
 
     The path format is handled according to the underlying operating system.

--- a/ipipeline/utils/system.py
+++ b/ipipeline/utils/system.py
@@ -9,34 +9,36 @@ from pathlib import Path
 from ipipeline.exceptions import SystemError
 
 
-def build_directory(
-    path: str, missing: bool = False, suppressed: bool = False
-) -> None:
-    """Creates a directory in the file system.
+def build_directory(path: str, **key_args: dict) -> None:
+    """Builds a directory in the file system.
 
-    The path format is handled according to the underlying operating system.
+    The path is handled according to the underlying operating system.
 
     Parameters
     ----------
     path : str
         Path of the directory.
-    missing : bool, default=False
-        Indicates if the missing parent directories should be created.
-    suppressed : bool, default=False
-        Indicates if the error should be suppressed or not.
+    key_args : dict
+        Key arguments of the mkdir method.
 
     Raises
     ------
     SystemError
-        Informs that the directory was not created in the file system.
+        Informs that the path was found in the file system.
+    SystemError
+        Informs that the path was not found in the file system.
     """
 
     try:
         path = Path(path).resolve()
-        path.mkdir(parents=missing, exist_ok=suppressed)
-    except (FileExistsError, FileNotFoundError) as error:
+        path.mkdir(**key_args)
+    except FileExistsError as error:
         raise SystemError(
-            'directory not created in the file system', f'path == {path}'
+            'path found in the file system', f'path == {path}'
+        ) from error
+    except FileNotFoundError as error:
+        raise SystemError(
+            'path not found in the file system', f'path == {path}'
         ) from error
 
 

--- a/ipipeline/utils/system.py
+++ b/ipipeline/utils/system.py
@@ -42,28 +42,34 @@ def build_directory(path: str, **key_args: dict) -> None:
         ) from error
 
 
-def build_file(path: str, suppressed: bool = False) -> None:
-    """Creates a file in the file system.
+def build_file(path: str, **key_args: dict) -> None:
+    """Builds a file in the file system.
 
-    The path format is handled according to the underlying operating system.
+    The path is handled according to the underlying operating system.
 
     Parameters
     ----------
     path : str
         Path of the file.
-    suppressed : bool, default=False
-        Indicates if the error should be suppressed or not.
+    key_args : dict
+        Key arguments of the touch method.
 
     Raises
     ------
     SystemError
-        Informs that the file was not created in the file system.
+        Informs that the path was found in the file system.
+    SystemError
+        Informs that the path was not found in the file system.
     """
 
     try:
         path = Path(path).resolve()
-        path.touch(exist_ok=suppressed)
-    except (FileExistsError, FileNotFoundError) as error:
+        path.touch(**key_args)
+    except FileExistsError as error:
         raise SystemError(
-            'file not created in the file system', f'path == {path}'
+            'path found in the file system', f'path == {path}'
+        ) from error
+    except FileNotFoundError as error:
+        raise SystemError(
+            'path not found in the file system', f'path == {path}'
         ) from error

--- a/tests/cli/test_actions.py
+++ b/tests/cli/test_actions.py
@@ -47,7 +47,7 @@ class TestCreateProject(TestCase):
         create_project(str(self._path.parents[0]), 'mock_proj')
 
         with self.assertRaisesRegex(
-            SystemError, r'directory not created in the file system: path == *'
+            SystemError, r'path found in the file system: path == *'
         ):
             create_project(str(self._path.parents[0]), 'mock_proj')
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -14,17 +14,29 @@ from ipipeline.exceptions import (
 
 
 class TestBaseError(TestCase):
-    def test_init(self) -> None:
-        error = BaseError('error descr', 'error == value')
+    def test_init__text_eq_str__causes_eq_list(self) -> None:
+        error = BaseError('error text', ['cause == item'])
 
-        self.assertEqual(error._descr, 'error descr')
-        self.assertEqual(error._detail, 'error == value')
+        self.assertEqual(error._text, 'error text')
+        self.assertListEqual(error._causes, ['cause == item'])
 
-    def test_str(self) -> None:
-        error = BaseError('error descr', 'error == value')
-        error_msg = error.__str__()
+    def test_str__text_eq_str__causes_eq_empty_cause(self) -> None:
+        error = BaseError('error text', [])
+        msg = error.__str__()
 
-        self.assertEqual(error_msg, 'error descr: error == value')
+        self.assertEqual(msg, 'error text: ')
+
+    def test_str__text_eq_str__causes_eq_single_cause(self) -> None:
+        error = BaseError('error text', ['cause == item'])
+        msg = error.__str__()
+
+        self.assertEqual(msg, 'error text: cause == item')
+
+    def test_str__text_eq_str__causes_eq_multiple_causes(self) -> None:
+        error = BaseError('error text', ['cause1 == item1', 'cause2 == item2'])
+        msg = error.__str__()
+
+        self.assertEqual(msg, 'error text: cause1 == item1, cause2 == item2')
 
 
 class TestBuildingError(TestCase):

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,16 +1,6 @@
 from unittest import TestCase
 
-from ipipeline.exceptions import (
-    BaseError, 
-    BuildingError, 
-    CatalogError, 
-    ExecutorError, 
-    InfoError, 
-    InstanceError, 
-    PipelineError, 
-    SortingError, 
-    SystemError
-)
+from ipipeline.exceptions import BaseError
 
 
 class TestBaseError(TestCase):
@@ -37,59 +27,3 @@ class TestBaseError(TestCase):
         msg = error.__str__()
 
         self.assertEqual(msg, 'error text: cause1 == item1, cause2 == item2')
-
-
-class TestBuildingError(TestCase):
-    def test_deriv(self) -> None:
-        error = BuildingError('', '')
-
-        self.assertIsInstance(error, BaseError)
-
-
-class TestCatalogError(TestCase):
-    def test_deriv(self) -> None:
-        error = CatalogError('', '')
-
-        self.assertIsInstance(error, BaseError)
-
-
-class TestExecutorError(TestCase):
-    def test_deriv(self) -> None:
-        error = ExecutorError('', '')
-
-        self.assertIsInstance(error, BaseError)
-
-
-class TestInfoError(TestCase):
-    def test_deriv(self) -> None:
-        error = InfoError('', '')
-
-        self.assertIsInstance(error, BaseError)
-
-
-class TestInstanceError(TestCase):
-    def test_deriv(self) -> None:
-        error = InstanceError('', '')
-
-        self.assertIsInstance(error, BaseError)
-
-
-class TestPipelineError(TestCase):
-    def test_deriv(self) -> None:
-        error = PipelineError('', '')
-
-        self.assertIsInstance(error, BaseError)
-
-
-class TestSortingError(TestCase):
-    def test_deriv(self) -> None:
-        error = SortingError('', '')
-
-        self.assertIsInstance(error, BaseError)
-
-
-class TestSystemError(TestCase):
-    def test_deriv(self) -> None:
-        error = SystemError('', '')
-
-        self.assertIsInstance(error, BaseError)

--- a/tests/utils/test_checking.py
+++ b/tests/utils/test_checking.py
@@ -4,12 +4,12 @@ from ipipeline.utils.checking import check_none
 
 
 class TestCheckNone(TestCase):
-    def test_check_none__data_eq_none(self) -> None:
-        data = check_none(None, 'd1')
+    def test_check_none__item_eq_none(self) -> None:
+        item = check_none(None, 'i1')
 
-        self.assertEqual(data, 'd1')
+        self.assertEqual(item, 'i1')
 
-    def test_check_none__data_ne_none(self) -> None:
-        data = check_none('d1', 'd2')
+    def test_check_none__item_ne_none(self) -> None:
+        item = check_none('i1', 'i2')
 
-        self.assertEqual(data, 'd1')
+        self.assertEqual(item, 'i1')

--- a/tests/utils/test_checking.py
+++ b/tests/utils/test_checking.py
@@ -1,0 +1,15 @@
+from unittest import TestCase
+
+from ipipeline.utils.checking import check_none
+
+
+class TestCheckNone(TestCase):
+    def test_check_none__data_eq_none(self) -> None:
+        data = check_none(None, 'd1')
+
+        self.assertEqual(data, 'd1')
+
+    def test_check_none__data_ne_none(self) -> None:
+        data = check_none('d1', 'd2')
+
+        self.assertEqual(data, 'd1')

--- a/tests/utils/test_instance.py
+++ b/tests/utils/test_instance.py
@@ -45,7 +45,7 @@ class MockClass4:
 
 
 class TestBuildRepr(TestCase):
-    def test_build_repr__inst_wi_params_wi_attrs(self) -> None:
+    def test_build_repr__inst_eq_mock_wi_params_wi_attrs(self) -> None:
         repr = build_repr(MockClass1(1, '2'))
 
         self.assertEqual(
@@ -53,7 +53,7 @@ class TestBuildRepr(TestCase):
             'MockClass1(param1=1, param2=\'2\', param3=[3], param4=[\'4\'])'
         )
 
-    def test_build_repr__inst_wi_params_wo_attrs(self) -> None:
+    def test_build_repr__inst_eq_mock_wi_params_wo_attrs(self) -> None:
         repr = build_repr(MockClass2(1, '2'))
 
         self.assertEqual(
@@ -61,12 +61,12 @@ class TestBuildRepr(TestCase):
             'MockClass2(param1=None, param2=None, param3=None, param4=None)'
         )
 
-    def test_build_repr__inst_wo_params_wi_attrs(self) -> None:
+    def test_build_repr__inst_eq_mock_wo_params_wi_attrs(self) -> None:
         repr = build_repr(MockClass3())
 
         self.assertEqual(repr, 'MockClass3()')
 
-    def test_build_repr__inst_wo_params_wo_attrs(self) -> None:
+    def test_build_repr__inst_eq_mock_wo_params_wo_attrs(self) -> None:
         repr = build_repr(MockClass4())
 
         self.assertEqual(repr, 'MockClass4()')

--- a/tests/utils/test_instance.py
+++ b/tests/utils/test_instance.py
@@ -1,21 +1,7 @@
 from unittest import TestCase
 
 from ipipeline.exceptions import InstanceError
-from ipipeline.utils.instance import (
-    check_none_arg, build_inst_repr, obtain_mod_inst
-)
-
-
-class TestCheckNoneArg(TestCase):
-    def test_none_arg(self) -> None:
-        arg = check_none_arg(None, 'a1')
-
-        self.assertEqual(arg, 'a1')
-
-    def test_str_arg(self) -> None:
-        arg = check_none_arg('a1', 'a2')
-
-        self.assertEqual(arg, 'a1')
+from ipipeline.utils.instance import build_inst_repr, obtain_mod_inst
 
 
 class MockClass1:

--- a/tests/utils/test_instance.py
+++ b/tests/utils/test_instance.py
@@ -1,8 +1,9 @@
+import sys
 from unittest import TestCase
 from typing import List
 
 from ipipeline.exceptions import InstanceError
-from ipipeline.utils.instance import build_repr, obtain_mod_inst
+from ipipeline.utils.instance import build_repr, get_inst
 
 
 class MockClass1:
@@ -71,22 +72,24 @@ class TestBuildRepr(TestCase):
         self.assertEqual(repr, 'MockClass4()')
 
 
-class TestObtainModInst(TestCase):
-    def test_valid_names(self) -> None:
-        instance = obtain_mod_inst('tests.utils.test_instance', 'MockClass1')
+class TestGetInst(TestCase):
+    def test_get_inst__mod_name_eq_mod__inst_name_eq_inst(self) -> None:
+        inst = get_inst('tests.utils.test_instance', 'MockClass1')
 
-        self.assertEqual(instance.__name__, 'MockClass1')
+        self.assertEqual(inst.__name__, 'MockClass1')
+        self.assertIn('ipipeline/tests', sys.path[-1])
 
-    def test_invalid_mod_name(self) -> None:
+    def test_get_inst__mod_name_ne_mod__inst_name_eq_inst(self) -> None:
         with self.assertRaisesRegex(
             InstanceError, 
-            r'inst_name not found in the module: inst_name == MockClass1'
+            r'mod_name not found in the package: '
+            r'mod_name == tests.utils.test_instance'
         ):
-            _ = obtain_mod_inst('tests.utils.test_instances', 'MockClass1')
+            _ = get_inst('tests.utils.test_instances', 'MockClass1')
 
-    def test_invalid_inst_name(self) -> None:
+    def test_get_inst__mod_name_eq_mod__inst_name_ne_inst(self) -> None:
         with self.assertRaisesRegex(
             InstanceError, 
-            r'inst_name not found in the module: inst_name == MockClass11'
+            r'inst_name not found in the module: inst_name == MockClass0'
         ):
-            _ = obtain_mod_inst('tests.utils.test_instance', 'MockClass11')
+            _ = get_inst('tests.utils.test_instance', 'MockClass0')

--- a/tests/utils/test_instance.py
+++ b/tests/utils/test_instance.py
@@ -1,24 +1,41 @@
 from unittest import TestCase
+from typing import List
 
 from ipipeline.exceptions import InstanceError
-from ipipeline.utils.instance import build_inst_repr, obtain_mod_inst
+from ipipeline.utils.instance import build_repr, obtain_mod_inst
 
 
 class MockClass1:
-    def __init__(self, param1: int, param2: str = '2') -> None:
+    def __init__(
+        self, 
+        param1: int, 
+        param2: str, 
+        param3: List[int] = [3], 
+        param4: List[str] = ['4']
+    ) -> None:
         self._param1 = param1
-        self.param2 = param2
+        self._param2 = param2
+        self.param3 = param3
+        self.param4 = param4
 
 
 class MockClass2:
-    def __init__(self, param1: int, param2: str = '2') -> None:
+    def __init__(
+        self, 
+        param1: int, 
+        param2: str, 
+        param3: List[int] = [3], 
+        param4: List[str] = ['4']
+    ) -> None:
         pass
 
 
 class MockClass3:
     def __init__(self) -> None:
         self._param1 = 1
-        self.param2 = '2'
+        self._param2 = '2'
+        self.param3 = [3]
+        self.param4 = ['4']
 
 
 class MockClass4:
@@ -26,24 +43,30 @@ class MockClass4:
         pass
 
 
-class TestBuildInstRepr(TestCase):
-    def test_inst_with_params_with_attrs(self) -> None:
-        repr = build_inst_repr(MockClass1(1))
+class TestBuildRepr(TestCase):
+    def test_build_repr__inst_wi_params_wi_attrs(self) -> None:
+        repr = build_repr(MockClass1(1, '2'))
 
-        self.assertEqual(repr, 'MockClass1(param1=1, param2=\'2\')')
+        self.assertEqual(
+            repr, 
+            'MockClass1(param1=1, param2=\'2\', param3=[3], param4=[\'4\'])'
+        )
 
-    def test_inst_with_params_without_attrs(self) -> None:
-        repr = build_inst_repr(MockClass2(1))
+    def test_build_repr__inst_wi_params_wo_attrs(self) -> None:
+        repr = build_repr(MockClass2(1, '2'))
 
-        self.assertEqual(repr, 'MockClass2(param1=None, param2=None)')
+        self.assertEqual(
+            repr, 
+            'MockClass2(param1=None, param2=None, param3=None, param4=None)'
+        )
 
-    def test_inst_without_params_with_attrs(self) -> None:
-        repr = build_inst_repr(MockClass3())
+    def test_build_repr__inst_wo_params_wi_attrs(self) -> None:
+        repr = build_repr(MockClass3())
 
         self.assertEqual(repr, 'MockClass3()')
 
-    def test_inst_without_params_without_attrs(self) -> None:
-        repr = build_inst_repr(MockClass4())
+    def test_build_repr__inst_wo_params_wo_attrs(self) -> None:
+        repr = build_repr(MockClass4())
 
         self.assertEqual(repr, 'MockClass4()')
 

--- a/tests/utils/test_system.py
+++ b/tests/utils/test_system.py
@@ -19,7 +19,7 @@ class TestBuildDirectory(TestCase):
         with self.assertRaisesRegex(
             SystemError, r'path found in the file system: path == *'
         ):
-            build_directory(str(self._path))
+            build_directory(str(self._path), exist_ok=False)
 
     def test_build_directory__path_ne_dir_wi_comps(self) -> None:
         build_directory(str(self._path))
@@ -38,17 +38,24 @@ class TestBuildFile(TestCase):
         self._path = Path(__file__).resolve().parents[0] / 'mock_file'
 
     def tearDown(self) -> None:
-        self._path.unlink()
+        if self._path.exists():
+            self._path.unlink()
 
-    def test_inexistent_file(self) -> None:
-        build_file(str(self._path), suppressed=False)
+    def test_build_file__path_eq_file_wi_comps(self) -> None:
+        build_file(str(self._path))
+
+        with self.assertRaisesRegex(
+            SystemError, r'path found in the file system: path == *'
+        ):
+            build_file(str(self._path), exist_ok=False)
+
+    def test_build_file__path_ne_file_wi_comps(self) -> None:
+        build_file(str(self._path))
 
         self.assertTrue(self._path.exists())
 
-    def test_existent_file(self) -> None:
-        build_file(str(self._path), suppressed=False)
-
+    def test_build_file__path_ne_file_wo_comps(self) -> None:
         with self.assertRaisesRegex(
-            SystemError, r'file not created in the file system: path == *'
+            SystemError, r'path not found in the file system: path == *'
         ):
-            build_file(str(self._path), suppressed=False)
+            build_file(str(self._path / 'mock_file'))

--- a/tests/utils/test_system.py
+++ b/tests/utils/test_system.py
@@ -10,20 +10,27 @@ class TestBuildDirectory(TestCase):
         self._path = Path(__file__).resolve().parents[0] / 'mock_dir'
 
     def tearDown(self) -> None:
-        self._path.rmdir()
+        if self._path.exists():
+            self._path.rmdir()
 
-    def test_inexistent_directory(self) -> None:
-        build_directory(str(self._path), missing=False, suppressed=False)
+    def test_build_directory__path_eq_dir_wi_comps(self) -> None:
+        build_directory(str(self._path))
+
+        with self.assertRaisesRegex(
+            SystemError, r'path found in the file system: path == *'
+        ):
+            build_directory(str(self._path))
+
+    def test_build_directory__path_ne_dir_wi_comps(self) -> None:
+        build_directory(str(self._path))
 
         self.assertTrue(self._path.exists())
 
-    def test_existent_directory(self) -> None:
-        build_directory(str(self._path), missing=False, suppressed=False)
-
+    def test_build_directory__path_ne_dir_wo_comps(self) -> None:
         with self.assertRaisesRegex(
-            SystemError, r'directory not created in the file system: path == *'
+            SystemError, r'path not found in the file system: path == *'
         ):
-            build_directory(str(self._path), missing=False, suppressed=False)
+            build_directory(str(self._path / 'mock_dir'))
 
 
 class TestBuildFile(TestCase):

--- a/tests/utils/test_system.py
+++ b/tests/utils/test_system.py
@@ -2,10 +2,10 @@ from pathlib import Path
 from unittest import TestCase
 
 from ipipeline.exceptions import SystemError
-from ipipeline.utils.system import create_directory, create_file
+from ipipeline.utils.system import build_directory, build_file
 
 
-class TestCreateDirectory(TestCase):
+class TestBuildDirectory(TestCase):
     def setUp(self) -> None:
         self._path = Path(__file__).resolve().parents[0] / 'mock_dir'
 
@@ -13,20 +13,20 @@ class TestCreateDirectory(TestCase):
         self._path.rmdir()
 
     def test_inexistent_directory(self) -> None:
-        create_directory(str(self._path), missing=False, suppressed=False)
+        build_directory(str(self._path), missing=False, suppressed=False)
 
         self.assertTrue(self._path.exists())
 
     def test_existent_directory(self) -> None:
-        create_directory(str(self._path), missing=False, suppressed=False)
+        build_directory(str(self._path), missing=False, suppressed=False)
 
         with self.assertRaisesRegex(
             SystemError, r'directory not created in the file system: path == *'
         ):
-            create_directory(str(self._path), missing=False, suppressed=False)
+            build_directory(str(self._path), missing=False, suppressed=False)
 
 
-class TestCreateFile(TestCase):
+class TestBuildFile(TestCase):
     def setUp(self) -> None:
         self._path = Path(__file__).resolve().parents[0] / 'mock_file'
 
@@ -34,14 +34,14 @@ class TestCreateFile(TestCase):
         self._path.unlink()
 
     def test_inexistent_file(self) -> None:
-        create_file(str(self._path), suppressed=False)
+        build_file(str(self._path), suppressed=False)
 
         self.assertTrue(self._path.exists())
 
     def test_existent_file(self) -> None:
-        create_file(str(self._path), suppressed=False)
+        build_file(str(self._path), suppressed=False)
 
         with self.assertRaisesRegex(
             SystemError, r'file not created in the file system: path == *'
         ):
-            create_file(str(self._path), suppressed=False)
+            build_file(str(self._path), suppressed=False)


### PR DESCRIPTION
All functions in this package were renamed to standardize the use of some verbs.

New test scenarios were added due to the splitting process applied in some error handlers that handled more than one error at a time.

As the utils package is used by all packages, imports and calls were also updated.